### PR TITLE
Add setup for package installation

### DIFF
--- a/face3d/mesh/cython/__init__.py
+++ b/face3d/mesh/cython/__init__.py
@@ -1,2 +1,0 @@
-# # compile cython beforehand ! ( python3 setup.py build_ext --inplace )
-# from . import mesh_core_cython

--- a/face3d/mesh/cython/__init__.py
+++ b/face3d/mesh/cython/__init__.py
@@ -1,0 +1,2 @@
+# # compile cython beforehand ! ( python3 setup.py build_ext --inplace )
+# from . import mesh_core_cython

--- a/face3d/mesh/cython/mesh_core.cpp
+++ b/face3d/mesh/cython/mesh_core.cpp
@@ -346,7 +346,7 @@ void _write_obj_with_colors_texture(string filename, string mtl_name,
 {
     int i;
 
-    ofstream obj_file(filename);
+    ofstream obj_file(filename.c_str());
 
     // first line of the obj file: the mtl name
     obj_file << "mtllib " << mtl_name << endl;

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+from distutils.core import setup
+from distutils.extension import Extension
+
+import numpy
+from Cython.Distutils import build_ext
+
+cmdclass = {'build_ext': build_ext}
+ext_modules = [Extension("face3d.mesh.cython.mesh_core_cython",
+                         sources=["face3d/mesh/cython/mesh_core_cython.pyx", "face3d/mesh/cython/mesh_core.cpp"],
+                         language='c++',
+                         include_dirs=[numpy.get_include(), '.'])]
+
+setup(
+    name='face3d',
+    cmdclass=cmdclass,
+    ext_modules=ext_modules,
+    version='1.0',
+    description='Python tools for 3D face: 3DMM, Mesh processing(transform, camera, light, render), '
+                '3D face representations.',
+    author='Yao Feng',
+    author_email='yaofeng1995@gmail.com',
+    packages=['face3d', 'face3d.mesh', 'face3d.mesh_numpy', 'face3d.morphable_model', 'face3d.mesh.cython'],
+)


### PR DESCRIPTION
If one want to use the package as standalone, it may be useful to have an installation that also wraps the c++ code, and compile it during installation of the whole `face3d` package.

What do you think about it @YadiraF ?

(Note: using this installation, the user needs to comment out the `sys.path.append('..')` line in the examples, in order to call the installed package)